### PR TITLE
Add MsmqTraceListener

### DIFF
--- a/SnakeEyes/MsmqTraceListener/MsmqTraceListener.cs
+++ b/SnakeEyes/MsmqTraceListener/MsmqTraceListener.cs
@@ -43,7 +43,7 @@ namespace SnakeEyes
                 MessageQueue.Create(MsmqQueueName);
             }
             MessageQueue messageQueue = new MessageQueue(MsmqQueueName);
-            messageQueue.Label = "SnakeEyesQueue";
+            messageQueue.Label = "SnakeEyesInbox";
 
             Message message = new Message()
             {
@@ -51,7 +51,7 @@ namespace SnakeEyes
                 Body = trace,
                 Formatter = new ActiveXMessageFormatter()
             };
-            messageQueue.Send(message);
+            messageQueue.Send(message, MessageQueueTransactionType.Single);
         }
     }
 }

--- a/SnakeEyes/MsmqTraceListener/MsmqTraceListener.cs
+++ b/SnakeEyes/MsmqTraceListener/MsmqTraceListener.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Messaging;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SnakeEyes
+{
+    public class MsmqTraceListener : TraceListener
+    {
+        public string MsmqQueueName { get { return Attributes["queueName"]; } }
+
+        public override void TraceEvent(TraceEventCache eventCache, string source, TraceEventType eventType, int id, string message)
+        {
+            if (Filter != null && !Filter.ShouldTrace(eventCache, source, eventType, id, message, null, null, null))
+                return;
+
+            SendMessage(message);
+        }
+
+        public override void Write(string message)
+        {
+            SendMessage(message);
+        }
+
+        public override void WriteLine(string message)
+        {
+            SendMessage(message);
+        }
+
+        protected override string[] GetSupportedAttributes()
+        {
+            return new string[] { "queueName" };
+        }
+
+        void SendMessage(string trace)
+        {
+            //From Windows Service, use this code
+            if (!MessageQueue.Exists(MsmqQueueName))
+            {
+                MessageQueue.Create(MsmqQueueName);
+            }
+            MessageQueue messageQueue = new MessageQueue(MsmqQueueName);
+            messageQueue.Label = "SnakeEyesQueue";
+
+            Message message = new Message()
+            {
+                Label = "SnakeMessage",
+                Body = trace,
+                Formatter = new ActiveXMessageFormatter()
+            };
+            messageQueue.Send(message);
+        }
+    }
+}

--- a/SnakeEyes/MsmqTraceListener/MsmqTraceListener.csproj
+++ b/SnakeEyes/MsmqTraceListener/MsmqTraceListener.csproj
@@ -45,5 +45,8 @@
     <Compile Include="MsmqTraceListener.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/SnakeEyes/MsmqTraceListener/MsmqTraceListener.csproj
+++ b/SnakeEyes/MsmqTraceListener/MsmqTraceListener.csproj
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7EB8483E-D24A-4D08-A2EF-9049224C1977}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MsmqTraceListener</RootNamespace>
+    <AssemblyName>MsmqTraceListener</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Messaging" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MsmqTraceListener.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/SnakeEyes/MsmqTraceListener/Properties/AssemblyInfo.cs
+++ b/SnakeEyes/MsmqTraceListener/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// Allgemeine Informationen über eine Assembly werden über die folgenden
+// Attribute gesteuert. Ändern Sie diese Attributwerte, um die Informationen zu ändern,
+// die einer Assembly zugeordnet sind.
+[assembly: AssemblyTitle("MsmqTraceListener")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MsmqTraceListener")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Durch Festlegen von ComVisible auf FALSE werden die Typen in dieser Assembly
+// für COM-Komponenten unsichtbar.  Wenn Sie auf einen Typ in dieser Assembly von
+// COM aus zugreifen müssen, sollten Sie das ComVisible-Attribut für diesen Typ auf "True" festlegen.
+[assembly: ComVisible(false)]
+
+// Die folgende GUID bestimmt die ID der Typbibliothek, wenn dieses Projekt für COM verfügbar gemacht wird
+[assembly: Guid("7eb8483e-d24a-4d08-a2ef-9049224c1977")]
+
+// Versionsinformationen für eine Assembly bestehen aus den folgenden vier Werten:
+//
+//      Hauptversion
+//      Nebenversion
+//      Buildnummer
+//      Revision
+//
+// Sie können alle Werte angeben oder Standardwerte für die Build- und Revisionsnummern verwenden,
+// indem Sie "*" wie unten gezeigt eingeben:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SnakeEyes/MsmqTraceListener/README.md
+++ b/SnakeEyes/MsmqTraceListener/README.md
@@ -1,0 +1,51 @@
+﻿# MsmqTraceListener
+
+This listener sends a trace event to a message queue.
+
+Config options:
+
+| Key             | Explaination                                                             | Default |
+| --------------- | ------------------------------------------------------------------------ | ------- |
+| queueName       | Name of the queue to send the traces to                                  |         |
+
+Here is a minimal configuration for the SnakeEyesService that sends the amount of free ram to the queue `SnakeEyesInbox` on the local computer:
+
+```xml
+<?xml version="1.0"?>
+<configuration>
+	<configSections>
+		<section name="TriggerEveryHour.Filter" type="System.Configuration.NameValueSectionHandler"/>
+		<section name="RAM_FreeBytes.PerfMonProbe" type="System.Configuration.NameValueSectionHandler"/>
+	</configSections>
+	<startup>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+	</startup>
+	<TriggerEveryHour.Filter>
+		<add key="NextTriggerTime" value="3600"/>
+		<add key="DelayTriggerTime" value="0"/>
+	</TriggerEveryHour.Filter>
+	<RAM_FreeBytes.PerfMonProbe>
+		<add key="CategoryName" value="Memory"/>
+		<add key="CounterName" value="Available MBytes"/>
+		<add key="MinValue" value="1024"/>
+		<add key="EventId" value="1"/>
+		<add key="EventType" value="Warning"/>
+		<add key="ProbeFrequency" value="5"/>
+	</RAM_FreeBytes.PerfMonProbe>
+	<system.diagnostics>
+		<sources>
+			<source name="RAM_FreeBytes.PerfMonProbe">
+				<listeners>
+					<clear/>
+					<add name="MsmqEvents"/>
+				</listeners>
+			</source>
+		</sources>
+		<sharedListeners>
+			<add type="SnakeEyes.MsmqTraceListener, MsmqTraceListener" name="MsmqEvents" queueName=".\Private$\SnakeEyesInbox">
+			</add>
+		</sharedListeners>
+	</system.diagnostics>
+</configuration>
+```
+

--- a/SnakeEyes/SnakeEyes.sln
+++ b/SnakeEyes/SnakeEyes.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.4
+VisualStudioVersion = 15.0.26228.9
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Probe", "Probe\Probe.csproj", "{7AE76F93-A62C-4A9F-9B69-BC0F3453DB50}"
 EndProject
@@ -26,6 +26,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WCFService", "WCFService\WCFService.csproj", "{A98B7761-8D6F-44FC-AE19-C9D0F234234A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileProbe", "FileProbe\FileProbe.csproj", "{3F501345-C388-4A9C-B4D7-327A2BDCC62D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MsmqTraceListener", "MsmqTraceListener\MsmqTraceListener.csproj", "{7EB8483E-D24A-4D08-A2EF-9049224C1977}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -81,6 +83,10 @@ Global
 		{3F501345-C388-4A9C-B4D7-327A2BDCC62D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3F501345-C388-4A9C-B4D7-327A2BDCC62D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3F501345-C388-4A9C-B4D7-327A2BDCC62D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7EB8483E-D24A-4D08-A2EF-9049224C1977}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7EB8483E-D24A-4D08-A2EF-9049224C1977}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7EB8483E-D24A-4D08-A2EF-9049224C1977}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7EB8483E-D24A-4D08-A2EF-9049224C1977}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SnakeEyes/SnakeEyesClient/SnakeEyesClient.csproj
+++ b/SnakeEyes/SnakeEyesClient/SnakeEyesClient.csproj
@@ -123,6 +123,10 @@
       <Project>{3f501345-c388-4a9c-b4d7-327a2bdcc62d}</Project>
       <Name>FileProbe</Name>
     </ProjectReference>
+    <ProjectReference Include="..\MsmqTraceListener\MsmqTraceListener.csproj">
+      <Project>{7eb8483e-d24a-4d08-a2ef-9049224c1977}</Project>
+      <Name>MsmqTraceListener</Name>
+    </ProjectReference>
     <ProjectReference Include="..\PerfMonProbe\PerfMonProbe.csproj">
       <Project>{370c2fcc-d490-4464-8c0f-f3018d6daa30}</Project>
       <Name>PerfMonProbe</Name>

--- a/SnakeEyes/SnakeEyesService/SnakeEyesService.csproj
+++ b/SnakeEyes/SnakeEyesService/SnakeEyesService.csproj
@@ -115,6 +115,10 @@
       <Project>{3f501345-c388-4a9c-b4d7-327a2bdcc62d}</Project>
       <Name>FileProbe</Name>
     </ProjectReference>
+    <ProjectReference Include="..\MsmqTraceListener\MsmqTraceListener.csproj">
+      <Project>{7eb8483e-d24a-4d08-a2ef-9049224c1977}</Project>
+      <Name>MsmqTraceListener</Name>
+    </ProjectReference>
     <ProjectReference Include="..\PerfMonProbe\PerfMonProbe.csproj">
       <Project>{370C2FCC-D490-4464-8C0F-F3018D6DAA30}</Project>
       <Name>PerfMonProbe</Name>


### PR DESCRIPTION
I've written a new trace listener that writes the events xml representation to a message queue using MSMQ. These "exported" messages can be used to gather the data on a central server and to create a history of the test results. See  https://github.com/jakobsack/snakeeyes-dashboard for a first draft of such a program.