### PR TITLE
Fix the installer if no value for "ServiceDependencies" is given.

### DIFF
--- a/SnakeEyes/SnakeEyesService/ProjectInstaller.cs
+++ b/SnakeEyes/SnakeEyesService/ProjectInstaller.cs
@@ -20,10 +20,12 @@ namespace SnakeEyes
             // http://raquila.com/software/configure-app-config-application-settings-during-msi-install/
             string assemblyPath = Context.Parameters["assemblypath"];
             Configuration config = ConfigurationManager.OpenExeConfiguration(assemblyPath);
-            string dependencies = config.AppSettings.Settings["ServiceDependencies"].Value;
-            if (dependencies != null)
-                serviceInstaller1.ServicesDependedOn = dependencies.Split(',');
 
+            KeyValueConfigurationElement dependencies = config.AppSettings.Settings["ServiceDependencies"];
+            if (dependencies != null)
+            {
+                serviceInstaller1.ServicesDependedOn = dependencies.Value.Split(',');
+            }
             Context.Parameters["assemblypath"] += "\" + /SERVICE";
             base.OnBeforeInstall(savedState);
         }


### PR DESCRIPTION
When running trying to install Snake Eyes Service I got the following error message:
```
X:\SnakeEyes>SnakeEyes.exe /install

Running a transacted installation.

Beginning the Install phase of the installation.
An exception occurred in the OnBeforeInstall event handler of SnakeEyes.ProjectInstaller.
System.NullReferenceException: Object reference not set to an instance of an object.

An exception occurred during the Install phase.
System.InvalidOperationException: An exception occurred in the OnBeforeInstall event handler of SnakeEyes.ProjectInstaller.
The inner exception System.NullReferenceException was thrown with the following error message: Object reference not set to an instance of an object..

The Rollback phase of the installation is beginning.
An exception occurred during the Rollback phase of the SnakeEyes.ProjectInstaller installer.
System.ArgumentException: The savedState dictionary does not contain the expected values and might have been corrupted.
An exception occurred during the Rollback phase of the installation. This exception will be ignored and the rollback will continue. However, the machine might not fully revert to its initial state after the rollback is complete.

The Rollback phase completed successfully.

The transacted install has completed.
The installation failed, and the rollback has been performed.
```

After the change it works fine.