### PR TITLE
Fix arguments order when creating a new message

### DIFF
--- a/SnakeEyes/MsmqTraceListener/MsmqTraceListener.cs
+++ b/SnakeEyes/MsmqTraceListener/MsmqTraceListener.cs
@@ -157,7 +157,7 @@ namespace SnakeEyes
                 return;
 
             KeyValuePair<string, string> msmqMsg = BuildMsmqMessage(source, eventType, id, message);
-            SendMessage(msmqMsg.Key, msmqMsg.Value);
+            SendMessage(msmqMsg.Value, msmqMsg.Key);
         }
 
         public override void Write(string message)


### PR DESCRIPTION
The method `SendMessage()` takes the body as the first argument and the label as the second one.