### PR TITLE
Make queue creation optional

### DIFF
--- a/SnakeEyes/MsmqTraceListener/MsmqTraceListener.cs
+++ b/SnakeEyes/MsmqTraceListener/MsmqTraceListener.cs
@@ -17,6 +17,8 @@ namespace SnakeEyes
 
         public string MessageFormatBody { get { return Attributes["formatBody"]; } }
 
+        public string CreateQueue { get { return Attributes["createQueue"]; } }
+
         protected MessageQueue MsmqQueue
         {
             get
@@ -54,13 +56,16 @@ namespace SnakeEyes
         protected virtual MessageQueue CreateMessageQueue()
         {
             //From Windows Service, use this code
-            if (!MessageQueue.Exists(MsmqQueueName))
+            if (!String.IsNullOrWhiteSpace(CreateQueue) && !MessageQueue.Exists(MsmqQueueName))
             {
                 MessageQueue.Create(MsmqQueueName);
             }
 
             MessageQueue messageQueue = new MessageQueue(MsmqQueueName);
-            messageQueue.Label = MsmqQueueLabel;
+            if (!String.IsNullOrWhiteSpace(CreateQueue))
+            {
+                messageQueue.Label = MsmqQueueLabel;
+            }
             return messageQueue;
         }
 
@@ -172,7 +177,7 @@ namespace SnakeEyes
 
         protected override string[] GetSupportedAttributes()
         {
-            return new string[] { "queueName", "queueLabel", "formatLabel", "formatBody" };
+            return new string[] { "queueName", "queueLabel", "formatLabel", "formatBody", "createQueue" };
         }
     }
 }

--- a/SnakeEyes/SnakeEyesService/Program.cs
+++ b/SnakeEyes/SnakeEyesService/Program.cs
@@ -25,7 +25,7 @@ namespace SnakeEyes
             AppDomain.CurrentDomain.ProcessExit += new EventHandler(CurrentDomain_ProcessExit);
             AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(CurrentDomain_UnhandledException);
 
-            if (Array.Exists(args, delegate(string arg) { return arg == "/install" || arg == "/INSTALL"; }))
+            if (Array.Exists(args, delegate(string arg) { return arg.ToLower() == "/install"; }))
             {
                 try
                 {
@@ -45,7 +45,7 @@ namespace SnakeEyes
                 return;
             }
 
-            if (Array.Exists(args, delegate(string arg) { return arg == "/uninstall" || arg == "/UNINSTALL"; }))
+            if (Array.Exists(args, delegate(string arg) { return arg.ToLower() == "/uninstall" ; }))
             {
                 try
                 {
@@ -65,7 +65,7 @@ namespace SnakeEyes
                 return;
             }
 
-            if (Array.Exists(args, delegate(string arg) { return arg == "/service" || arg == "/SERVICE"; }))
+            if (Array.Exists(args, delegate(string arg) { return arg.ToLower() == "/service"; }))
             {
                 ServiceBase[] ServicesToRun;
 


### PR DESCRIPTION
This PR makes the creation of queues optional in MsmqTraceListener. This change was necessary because it was not possible to send messages to private queues on other computers with this option turned on.

Furthermore the command line arguments are now case insensitive.