### PR TITLE
Add reference to Probe in nUnitTest project

### DIFF
--- a/SnakeEyes/nUnitTest/nUnitTest.csproj
+++ b/SnakeEyes/nUnitTest/nUnitTest.csproj
@@ -74,6 +74,10 @@
       <Project>{0e02c78e-8358-43af-82d5-94e99d4392c0}</Project>
       <Name>PingProbe</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Probe\Probe.csproj">
+      <Project>{7ae76f93-a62c-4a9f-9b69-bc0f3453db50}</Project>
+      <Name>Probe</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />


### PR DESCRIPTION
When trying to build the tool using _nant 0.92_ and _msbuild 4.6.1087.0_ I got the following error:

```
     [exec] MSBuild auto-detection: using msbuild version '14.0' from 'C:\Program Files (x86)\MSBuild\14.0\bin'.
     [exec] All packages listed in packages.config are already installed.
     [exec] Microsoft (R) Build Engine version 4.6.1087.0
     [exec] [Microsoft .NET Framework, version 4.0.30319.42000]
     [exec] Copyright (C) Microsoft Corporation. All rights reserved.
...
     [exec] "d:\buildroot\Tools\SnakeEyes\Service\SnakeEyes\SnakeEyes.sln" (Build target) (1) ->
     [exec] "d:\buildroot\Tools\SnakeEyes\Service\SnakeEyes\nUnitTest\nUnitTest.csproj" (default target) (8) ->
     [exec] (CoreCompile target) -> 
     [exec]   FileProbeTest.cs(67,13): error CS0012: The type 'SnakeEyes.IProbe' is defined in an assembly that is not referenced. You must add a reference to assembly 'Probe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'. [d:\buildroot\Tools\SnakeEyes\Service\SnakeEyes\nUnitTest\nUnitTest.csproj]
```

This patch fixes the problem.